### PR TITLE
Fix critical bugs in function_of_decision_section task

### DIFF
--- a/tasks/function_of_decision_section/README.md
+++ b/tasks/function_of_decision_section/README.md
@@ -19,7 +19,7 @@
 
 Lawyers reading prior court decisions must be able to identify the function that each section of the written decision serves within the context of the whole. Beginning lawyers in law school are taught to do so intentionally and explicitly as they read cases. As lawyers become more experienced over time, the process becomes second nature. This task is to classify a paragraph extracted from a written decision into one of seven possible categories: Facts, Procedural History, Issue, Rule, Analysis, Conclusion, or Decree.
 
-1. Facts - The paragraph describes the faction background that led up to the present lawsuit.
+1. Facts - The paragraph describes the factual background that led up to the present lawsuit.
 2. Procedural History - The paragraph describes the course of litigation that led to the current proceeding before the court.
 3. Issue - The paragraph describes the legal or factual issue that must be resolved by the court.
 4. Rule - The paragraph describes a rule of law relevant to resolving the issue.

--- a/tasks/function_of_decision_section/base_prompt.txt
+++ b/tasks/function_of_decision_section/base_prompt.txt
@@ -1,6 +1,6 @@
 Classify the following text using the following definitions. 
 
-- Facts: The paragraph describes the faction background that led up to the present lawsuit.
+- Facts: The paragraph describes the factual background that led up to the present lawsuit.
 - Procedural History: The paragraph describes the course of litigation that led to the current proceeding before the court.
 - Issue: The paragraph describes the legal or factual issue that must be resolved by the court.
 - Rule: The paragraph describes a rule of law relevant to resolving the issue.
@@ -10,7 +10,7 @@ Classify the following text using the following definitions.
 
 
 Text: We need go no further. For aught that appears, the appellant was fairly tried before an able and thoughtful judge and an impartial jury, justly convicted, and lawfully sentenced. For the reasons elucidated above, the judgment of the district court is Affirmed.
-Label: Facts
+Label: Decree
 
 Text: Lassiter pled guilty to kidnapping, 18 U.S.C. § 1201(a), to assault with intent to kill while armed, D.C. Code §§ 22-401, -4502, and to using a firearm during a crime of violence, 18 U.S.C. § 924(c)(1)(A).	
 Label: Procedural History

--- a/tasks/function_of_decision_section/claude_prompt.txt
+++ b/tasks/function_of_decision_section/claude_prompt.txt
@@ -1,5 +1,5 @@
 Classify the following text using the following definitions. 
-- Facts: The paragraph describes the faction background that led up to the present lawsuit.
+- Facts: The paragraph describes the factual background that led up to the present lawsuit.
 - Procedural History: The paragraph describes the course of litigation that led to the current proceeding before the court.
 - Issue: The paragraph describes the legal or factual issue that must be resolved by the court.
 - Rule: The paragraph describes a rule of law relevant to resolving the issue.
@@ -9,7 +9,7 @@ Classify the following text using the following definitions.
 
 <example>
 Text: We need go no further. For aught that appears, the appellant was fairly tried before an able and thoughtful judge and an impartial jury, justly convicted, and lawfully sentenced. For the reasons elucidated above, the judgment of the district court is Affirmed.
-Label: Facts
+Label: Decree
 </example>
 
 <example>

--- a/tasks/function_of_decision_section/train.tsv
+++ b/tasks/function_of_decision_section/train.tsv
@@ -1,5 +1,5 @@
 index	Citation	Paragraph	answer
-0	1 F.4th 100	We need go no further. For aught that appears, the appellant was fairly tried before an able and thoughtful judge and an impartial jury, justly convicted, and lawfully sentenced. For the reasons elucidated above, the judgment of the district court is Affirmed.	Facts
+0	1 F.4th 100	We need go no further. For aught that appears, the appellant was fairly tried before an able and thoughtful judge and an impartial jury, justly convicted, and lawfully sentenced. For the reasons elucidated above, the judgment of the district court is Affirmed.	Decree
 1	1 F.4th 25	Lassiter pled guilty to kidnapping, 18 U.S.C. § 1201(a), to assault with intent to kill while armed, D.C. Code §§ 22-401, -4502, and to using a firearm during a crime of violence, 18 U.S.C. § 924(c)(1)(A).	Procedural History
 2	1 F.4th 87	In this venue, the appellant advances two claims of trial error and a cluster of claims of sentencing error.1 Since none possesses even a patina of plausibility, we make short shrift of them.	Issue
 3	1 F.4th 1	On appeal from a dismissal in favor of a foreign sovereign on grounds of sovereign immunity, we assume the unchallenged factual allegations in the complaint to be true. Simon v. Republic of Hungary, 812 F.3d 127, 135 (D.C. Cir. 2016).	Rule


### PR DESCRIPTION
## Summary

This PR fixes two critical data quality issues in the `function_of_decision_section` task that significantly impact model performance.

## Bugs Fixed

### 1. Typo: "faction background" → "factual background"
The typo appears in the definition of the "Facts" category and confuses the task definition.

### 2. Mislabeled Example
Text containing "judgment of the district court is Affirmed" was incorrectly labeled as "Facts" when it should be "Decree". This creates contradictory examples in the few-shot prompts.

## Evidence

The first example in the prompt shows:
```
Text: We need go no further... the judgment of the district court is Affirmed.
Label: Facts ❌ (Should be Decree)
```

While the seventh example correctly shows:
```
Text: For these reasons, we AFFIRM.
Label: Decree ✓
```

## Performance Impact

These bugs cause models to receive contradictory signals from the few-shot examples, which significantly degrades performance on this task. Correcting these issues should lead to more consistent and accurate model outputs.