### PR TITLE
Fix: successor_liability scored with balanced-accuracy instead of its F1 metric

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -152,7 +152,6 @@ EXACT_MATCH_BALANCED_ACC_TASKS = [
     "privacy_policy_qa",
     "proa",
     "sara_entailment",
-    "successor_liability",
     "scalr",
     "supply_chain_disclosure_best_practice_accountability",
     "supply_chain_disclosure_best_practice_audits",


### PR DESCRIPTION
### Problem
`successor_liability` is in `EXACT_MATCH_BALANCED_ACC_TASKS`, and `evaluate()` checks `if task in EXACT_MATCH_BALANCED_ACC_TASKS:` **before** the dedicated `elif task == "successor_liability":`. So `evaluate("successor_liability", ...)` always returns exact-match balanced accuracy, and `evaluate_successor_liability` (the intended F1) is **unreachable dead code**.

Because the gold answers are multi-label exception sets, exact-match balanced-accuracy scores nearly everything wrong (a generation never exactly equals the stringified label set), silently and substantially understating performance.

### Repro
```python
from evaluation import evaluate, evaluate_successor_liability
g = ["this is a de facto merger and a mere continuation"]
a = ["de facto merger,mere continuation"]
print(evaluate("successor_liability", g, a))        # 0.0  (balanced-acc path)
print(evaluate_successor_liability(g, a))            # 1.0  (intended F1)
```

### Fix
Remove `successor_liability` from `EXACT_MATCH_BALANCED_ACC_TASKS` so the dispatcher reaches the dedicated F1 branch. The list is only used by the `evaluate()` dispatch, so nothing else is affected.