### PR TITLE
Fix: evaluate_successor_liability returns ~0 on the HuggingFace answer format

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -240,6 +240,29 @@ def evaluate_exact_match_balanced_accuracy(generations: List[str], answers: List
     return balanced_accuracy_score(normalized_answers, normalized_gens)
 
 
+def _parse_answer_list(answer):
+    """Parse a successor-liability answer into a list of exception labels.
+
+    The canonical task TSVs use bare comma-separated values
+    ("de facto merger,mere continuation"), but the HuggingFace `nguha/legalbench`
+    mirror serializes the same field as a (sometimes double-quoted) Python list
+    repr ("['de facto merger', 'mere continuation']"). Accept either so callers
+    get correct scores regardless of which distribution they loaded.
+    """
+    s = str(answer).strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in "\"'":
+        s = s[1:-1].strip()
+    if s.startswith("[") and s.endswith("]"):
+        try:
+            import ast
+            parsed = ast.literal_eval(s)
+            if isinstance(parsed, (list, tuple)):
+                return [str(x).strip() for x in parsed]
+        except (ValueError, SyntaxError):
+            s = s.strip("[]").replace("'", "").replace('"', "")
+    return [x.strip() for x in s.split(",") if x.strip()]
+
+
 def evaluate_successor_liability(generations: List[str], answers: List[str]):
     """
     For successor liability, we measure F1 over the predicted exceptions.
@@ -253,7 +276,7 @@ def evaluate_successor_liability(generations: List[str], answers: List[str]):
     tp, fp, fn = 0, 0, 0
     for i in range(len(generations)):
         predictions = [c for c in CLASSES if c in str(generations[i])]
-        sample_answers = str(answers[i]).split(",")
+        sample_answers = _parse_answer_list(answers[i])
 
         for j in range(len(predictions)):
             if predictions[j] in sample_answers:


### PR DESCRIPTION
### Problem
`evaluate_successor_liability` parses the gold answer with `str(answers[i]).split(",")`. That matches the canonical task TSVs (`de facto merger,mere continuation`), but the HuggingFace `nguha/legalbench` mirror serializes the same field as a (sometimes double-quoted) Python list repr:
```
"['de facto merger', 'mere continuation']"
```
Loading answers from HF and scoring with the official scorer yields **~0 F1 with no error**, because the split produces tokens like `"['de facto merger'"` that never match a `CLASS`.

Since the README points users to the HF dataset as the primary distribution channel, the scorer should accept both serializations.

### Fix
Add a small `_parse_answer_list` helper that handles bare comma-separated **or** list-repr answers, and use it in `evaluate_successor_liability`. Behavior on the canonical TSV format is unchanged.

> Note: this complements (and depends on) the companion PR that removes `successor_liability` from `EXACT_MATCH_BALANCED_ACC_TASKS` — without that, this F1 path isn't reached. The root cause is a TSV-vs-HF serialization mismatch; this PR hardens the scorer, and the HF dataset could separately be re-serialized to match the TSVs.