### PR TITLE
Fix: scorers crash on empty input (UnboundLocalError / ZeroDivisionError)

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -250,6 +250,8 @@ def evaluate_successor_liability(generations: List[str], answers: List[str]):
         "de facto merger",
         "mere continuation",
     ]
+    if not generations:
+        return 0.0
     tp, fp, fn = 0, 0, 0
     for i in range(len(generations)):
         predictions = [c for c in CLASSES if c in str(generations[i])]
@@ -311,6 +313,8 @@ def evaluate_definition_extraction(generations: List[str], answers: List[str]):
     matches ground truth.
     """
 
+    if not generations:
+        return 0.0
     total = 0
     correct = 0
     for i in range(len(generations)):


### PR DESCRIPTION
### Problem
Two scorers raise on an empty `generations` list instead of returning a score:

- `evaluate_successor_liability` binds `f1` only inside the per-sample loop → `UnboundLocalError` when `generations == []`.
- `evaluate_definition_extraction` ends in `correct / total` → `ZeroDivisionError` when `total == 0`.

An empty list is a normal degenerate case (a task whose generations all failed to parse, a zero-length slice, etc.).

### Fix
Return `0.0` in both when there are no generations.